### PR TITLE
Fixes panic while having 2 structs having slices being compared

### DIFF
--- a/document_base.go
+++ b/document_base.go
@@ -178,7 +178,7 @@ func (self *DocumentBase) DefaultValidate() (bool, []error) {
 
 		} else {
 
-			isSet = fieldValue.Interface() != reflect.Zero(reflect.TypeOf(fieldValue.Interface())).Interface()
+			isSet = !reflect.DeepEqual(fieldValue.Interface(), reflect.Zero(reflect.TypeOf(fieldValue.Interface())).Interface())
 		}
 
 		if required && !isSet {


### PR DESCRIPTION
Hi!

I'm using mongodm with a project using some protobuf, and I stumbled upon this panic:
```
2016/05/06 17:48:18 runtime error: comparing uncomparable type proto.Profilegoroutine 36 [running]:
runtime/debug.Stack(0x0, 0x0, 0x0)
    /usr/local/go/src/runtime/debug/stack.go:24 +0x80
github.com/micro/go-micro/server.(*rpcServer).accept.func1(0x7f0f670a8240, 0xc820196140)
    /home/dolanor/go/src/github.com/micro/go-micro/server/rpc_server.go:50 +0x53
panic(0xb6aa60, 0xc820486be0)
    /usr/local/go/src/runtime/panic.go:426 +0x4e9
github.com/zebresel-com/mongodm.(*DocumentBase).DefaultValidate(0xc82014c480, 0xc820129a68, 0x0, 0x0, 0x0)
    /home/dolanor/go/src/github.com/zebresel-com/mongodm/document_base.go:185 +0x3c2a
github.com/zebresel-com/mongodm.(*DocumentBase).Validate(0xc82014c480, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
    /home/dolanor/go/src/github.com/zebresel-com/mongodm/document_base.go:83 +0x32
github.com/zebresel-com/mongodm.(*DocumentBase).Save(0xc82014c480, 0x0, 0x0)
    /home/dolanor/go/src/github.com/zebresel-com/mongodm/document_base.go:410 +0x9c
github.com/org/api/user-srv/db.CreateProfile(0xc8200bc300, 0x0, 0x0)
```

From my investigation, it is the line I corrected that crashed because of comparing 2 slices.
I don't have more time to investigate, but this fixed my problem.