### PR TITLE
Exposing session to the public

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+# Intellij
+.idea

--- a/document_base.go
+++ b/document_base.go
@@ -419,7 +419,7 @@ func (self *DocumentBase) Save() error {
 	 * original session to wait." see: http://godoc.org/labix.org/v2/mgo#Session.Clone
 	 */
 
-	session := self.connection.session.Clone()
+	session := self.connection.Session.Clone()
 	defer session.Close()
 
 	collection := session.DB(self.connection.Config.DatabaseName).C(self.collection.Name)


### PR DESCRIPTION
I thought about a couple of possibilities for expanding `mongodm.Config`(#7). At first, I thought about adding extra fields to pass into the `Config` struct itself, but I think exposing the `session` field to the public would be a cleaner solution. This would allow mongodm users to set their own options on the session, which would avoid checking if those configs were not set and then setting them to the default values. 


In addition, I went ahead and removed the `database` field from the `Config` struct because it was only used a single time in the codebase. It was replaced by `session.DB("")` in that line because that would return the db that was given to the dial info. I didn't know if that was the direction this ODM is planning to take, so please let me know if I should make any other changes and I will be happy to do so. 

