### PR TITLE
+ Skip unexported fields as reflection will panic if accessed

### DIFF
--- a/document_base.go
+++ b/document_base.go
@@ -112,6 +112,11 @@ func (self *DocumentBase) DefaultValidate() (bool, []error) {
 
 		fieldName := fieldType.Field(fieldIndex).Name
 		fieldElem := documentValue.Field(fieldIndex)
+		
+		// Skip unexported fields as refection will throw a panic if trying to access its value
+		if field.PkgPath != "" && !field.Anonymous {
+			continue
+		}
 
 		// Get element of field by checking if pointer or copy
 		if fieldElem.Kind() == reflect.Ptr || fieldElem.Kind() == reflect.Interface {


### PR DESCRIPTION
Currently if used with Struct that have unexported fields, the Save() method will panic, fixing this.