### PR TITLE
Added objectidlist to runpopulation

### DIFF
--- a/validation.go
+++ b/validation.go
@@ -17,7 +17,7 @@ func validateRegexp(regex string, target string) bool {
 	match, err := regexp.MatchString(regex, target)
 
 	if err != nil {
-		fmt.Println("%v", err)
+		fmt.Println(err)
 	}
 
 	return match


### PR DESCRIPTION
I have been having some problms populating, after looking at the code I noticed that the type switch for runPopulation onlye expects bson.ObjectId or a list of empty interfaces.
I added a check for a list of ObjectIds, which basically does the same that the list of empty interfaces does